### PR TITLE
Update "MainPage.java" to support Android 'L'

### DIFF
--- a/Examples/BLEController/src/com/redbear/redbearbleclient/MainPage.java
+++ b/Examples/BLEController/src/com/redbear/redbearbleclient/MainPage.java
@@ -67,10 +67,16 @@ public class MainPage extends Activity {
 		actionBar.setCustomView(actionbar_layout);
 
 		setContentView(R.layout.activity_main_page);
-
+		
+		/*
 		String osVersion = Build.VERSION.RELEASE;
 		if ((osVersion.charAt(0)) == '4' && (osVersion.charAt(1) == '.')
 				&& (osVersion.charAt(2) >= '3')) {
+		*/
+		
+		int sdkVersion = android.os.Build.VERSION.SDK_INT;
+        	
+        	if(sdkVersion >= 18) {
 
 		} else {
 			AlertDialog.Builder dialog = new AlertDialog.Builder(MainPage.this);


### PR DESCRIPTION
Using something such as OS Version worked fine in the past but for something such as Android 'L' we should use SDK version or the app will not open on the phone since it will go to the else statement.  I was running into this problem and this is the solution that worked for me.
